### PR TITLE
Add option to delay file creation to world load

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	}
 
 	// check for the latest versions at https://jitpack.io/#Minecraft-Java-Edition-Speedrunning/sodium
-	modCompileOnly "com.github.Minecraft-Java-Edition-Speedrunning:sodium:d488d3a782"
+	modCompileOnly "com.github.Minecraft-Java-Edition-Speedrunning:sodium:0dd4b2d65a"
 
 	// check for the latest versions at https://jitpack.io/#kingcontaria/fastreset
 	modCompileOnly ("com.github.KingContaria:fastreset:82fe8eb3b2") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.16.1-build.24
 loader_version=0.16.5
 
 # Mod Properties
-mod_version=1.4
+mod_version=1.4.1
 maven_group=me.contaria
 archives_base_name=seedqueue
 

--- a/src/main/java/me/contaria/seedqueue/SeedQueue.java
+++ b/src/main/java/me/contaria/seedqueue/SeedQueue.java
@@ -1,6 +1,7 @@
 package me.contaria.seedqueue;
 
 import com.google.gson.JsonParseException;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import me.contaria.seedqueue.compat.ModCompat;
 import me.contaria.seedqueue.debug.SeedQueueSystemInfo;
 import me.contaria.seedqueue.debug.SeedQueueWatchdog;
@@ -20,6 +21,7 @@ import net.minecraft.text.TranslatableText;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -42,6 +44,13 @@ public class SeedQueue implements ClientModInitializer {
     public static final ThreadLocal<SeedQueueEntry> LOCAL_ENTRY = new ThreadLocal<>();
     public static SeedQueueEntry currentEntry;
     public static SeedQueueEntry selectedEntry;
+
+    public static boolean cancelDirectoryCreate(File instance, Operation<Boolean> original) {
+        if (config.delayFileCreation && inQueue()) {
+            return true;
+        }
+        return original.call(instance);
+    }
 
     @Override
     public void onInitializeClient() {

--- a/src/main/java/me/contaria/seedqueue/SeedQueueConfig.java
+++ b/src/main/java/me/contaria/seedqueue/SeedQueueConfig.java
@@ -123,6 +123,9 @@ public class SeedQueueConfig implements SpeedrunConfig {
     @Config.Category("performance")
     public boolean reduceLevelList = true;
 
+    @Config.Category("performance")
+    public boolean delayFileCreation = true;
+
     @Config.Category("misc")
     @Config.Numbers.Whole.Bounds(min = -1, max = 500, enforce = Config.Numbers.EnforceBounds.MIN_ONLY)
     public long chunkMapFreezing = -1;

--- a/src/main/java/me/contaria/seedqueue/interfaces/SQLevelStorageSession.java
+++ b/src/main/java/me/contaria/seedqueue/interfaces/SQLevelStorageSession.java
@@ -1,0 +1,7 @@
+package me.contaria.seedqueue.interfaces;
+
+import java.io.IOException;
+
+public interface SQLevelStorageSession {
+    void seedQueue$createLock() throws IOException;
+}

--- a/src/main/java/me/contaria/seedqueue/mixin/client/MinecraftClientMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/client/MinecraftClientMixin.java
@@ -46,15 +46,13 @@ import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
-import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.io.File;
 import java.net.Proxy;
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -232,7 +230,7 @@ public abstract class MinecraftClientMixin {
     private void queueServer(MinecraftClient client, IntegratedServer server, Operation<Void> original, @Local LevelStorage.Session session, @Local MinecraftClient.IntegratedResourceManager resourceManager, @Local YggdrasilAuthenticationService yggdrasilAuthenticationService, @Local MinecraftSessionService minecraftSessionService, @Local GameProfileRepository gameProfileRepository, @Local UserCache userCache) {
         if (SeedQueue.inQueue()) {
             ((SQMinecraftServer) server).seedQueue$setExecutor(SeedQueueExecutorWrapper.SEEDQUEUE_EXECUTOR);
-            SeedQueue.add(new SeedQueueEntry(server, session, resourceManager, yggdrasilAuthenticationService, minecraftSessionService, gameProfileRepository, userCache));
+            SeedQueue.add(new SeedQueueEntry(server, session, resourceManager, yggdrasilAuthenticationService, minecraftSessionService, gameProfileRepository, userCache,null));
             return;
         }
         original.call(client, server);
@@ -371,7 +369,7 @@ public abstract class MinecraftClientMixin {
             )
     )
     private boolean cancelSessionLevelDatInit(LevelStorage.Session instance, RegistryTracker registryTracker, SaveProperties saveProperties) {
-        return SeedQueue.inQueue() || SeedQueue.currentEntry == null;
+        return !SeedQueue.config.delayFileCreation;
     }
 
     @WrapWithCondition(

--- a/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/profiling/ChunkRenderManagerMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/compat/sodium/profiling/ChunkRenderManagerMixin.java
@@ -245,19 +245,6 @@ public abstract class ChunkRenderManagerMixin {
             method = "update",
             at = @At(
                     value = "INVOKE",
-                    target = "Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager;unloadPending()V",
-                    remap = false
-            ),
-            remap = true
-    )
-    private void profileUnloadPending(CallbackInfo ci) {
-        SeedQueueProfiler.swap("unload_pending");
-    }
-
-    @Inject(
-            method = "update",
-            at = @At(
-                    value = "INVOKE",
                     target = "Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderManager;setup(Lnet/minecraft/client/render/Camera;)V"
             ),
             remap = true

--- a/src/main/java/me/contaria/seedqueue/mixin/server/MinecraftServerMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/server/MinecraftServerMixin.java
@@ -1,6 +1,7 @@
 package me.contaria.seedqueue.mixin.server;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.contaria.seedqueue.SeedQueue;
@@ -23,8 +24,10 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.io.File;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -268,4 +271,5 @@ public abstract class MinecraftServerMixin extends ReentrantThreadExecutor<Serve
     public int seedQueue$incrementAndGetEntityID() {
         return this.maxEntityId.incrementAndGet();
     }
+
 }

--- a/src/main/java/me/contaria/seedqueue/mixin/server/optimization/FileResourcePackProviderMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/server/optimization/FileResourcePackProviderMixin.java
@@ -1,0 +1,25 @@
+package me.contaria.seedqueue.mixin.server.optimization;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.contaria.seedqueue.SeedQueue;
+import net.minecraft.resource.FileResourcePackProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.io.File;
+
+@Mixin(FileResourcePackProvider.class)
+public class FileResourcePackProviderMixin {
+
+    @WrapOperation(
+            method = "register",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/io/File;mkdirs()Z"
+            )
+    )
+    private boolean delayDirectoryCreate(File instance, Operation<Boolean> original) {
+        return SeedQueue.cancelDirectoryCreate(instance, original);
+    }
+}

--- a/src/main/java/me/contaria/seedqueue/mixin/server/optimization/LevelStorageSessionMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/server/optimization/LevelStorageSessionMixin.java
@@ -1,0 +1,52 @@
+package me.contaria.seedqueue.mixin.server.optimization;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.contaria.seedqueue.SeedQueue;
+import me.contaria.seedqueue.interfaces.SQLevelStorageSession;
+import me.contaria.seedqueue.interfaces.SQMinecraftServer;
+import net.minecraft.world.level.storage.LevelStorage;
+import net.minecraft.world.level.storage.SessionLock;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+@Mixin(LevelStorage.Session.class)
+public class LevelStorageSessionMixin  implements SQLevelStorageSession {
+    @Shadow @Mutable
+    private SessionLock lock;
+
+    @Shadow @Final private Path directory;
+
+    @WrapOperation(
+            method = "<init>",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/storage/SessionLock;create(Ljava/nio/file/Path;)Lnet/minecraft/world/level/storage/SessionLock;"
+            )
+    )
+    private SessionLock skipSessionLockCreation(Path path, Operation<SessionLock> original) throws IOException {
+        return SeedQueue.inQueue()? null : original.call(path);
+    }
+
+    public void seedQueue$createLock() throws IOException {
+        this.lock = SessionLock.create(this.directory);
+    }
+
+    @Inject(method = "checkValid", at = @At("HEAD"),cancellable = true)
+    private void dontRequireLockWhileInQueue(CallbackInfo ci) {
+        if (SeedQueue.inQueue() || SeedQueue.getThreadLocalEntry().isPresent()) {
+            ci.cancel();
+        }
+    }
+
+}

--- a/src/main/java/me/contaria/seedqueue/mixin/server/optimization/ServerChunkManagerMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/server/optimization/ServerChunkManagerMixin.java
@@ -1,0 +1,37 @@
+package me.contaria.seedqueue.mixin.server.optimization;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.contaria.seedqueue.SeedQueue;
+import me.contaria.seedqueue.interfaces.SQMinecraftServer;
+import net.minecraft.server.world.ServerChunkManager;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.io.File;
+
+@Mixin(ServerChunkManager.class)
+public class ServerChunkManagerMixin {
+
+    @Shadow @Final private ServerWorld world;
+
+    @WrapOperation(
+            method = "<init>",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/io/File;mkdirs()Z"
+            )
+    )
+    private boolean delayDirectoryCreate(File instance, Operation<Boolean> original) {
+        SQMinecraftServer server = (SQMinecraftServer) this.world.getServer();
+        if(server.seedQueue$inQueue()){
+            return true;
+        } else {
+            return original.call(instance);
+        }
+    }
+
+}

--- a/src/main/java/me/contaria/seedqueue/mixin/server/optimization/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/server/optimization/ThreadedAnvilChunkStorageMixin.java
@@ -7,10 +7,13 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.poi.PointOfInterestStorage;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.function.BooleanSupplier;
 
 @Mixin(ThreadedAnvilChunkStorage.class)
 public abstract class ThreadedAnvilChunkStorageMixin {

--- a/src/main/java/me/contaria/seedqueue/mixin/server/optimization/WorldSaveHandlerMixin.java
+++ b/src/main/java/me/contaria/seedqueue/mixin/server/optimization/WorldSaveHandlerMixin.java
@@ -1,0 +1,26 @@
+package me.contaria.seedqueue.mixin.server.optimization;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.contaria.seedqueue.SeedQueue;
+import net.minecraft.world.WorldSaveHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.io.File;
+
+@Mixin(WorldSaveHandler.class)
+public class WorldSaveHandlerMixin {
+
+    @WrapOperation(
+            method = "<init>",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/io/File;mkdirs()Z"
+            )
+    )
+    private boolean delayDirectoryCreate(File instance, Operation<Boolean> original) {
+        return SeedQueue.cancelDirectoryCreate(instance, original);
+    }
+
+}

--- a/src/main/resources/assets/seedqueue/lang/en_us.json
+++ b/src/main/resources/assets/seedqueue/lang/en_us.json
@@ -129,6 +129,8 @@
   "speedrunapi.config.seedqueue.option.reduceSchedulingBudget.description": "Reduces the amount of Sodium chunk rebuilds scheduled per frame. This improves framerate stability at the cost of slower chunk loads.",
   "speedrunapi.config.seedqueue.option.reduceLevelList": "Reduce World List",
   "speedrunapi.config.seedqueue.option.reduceLevelList.description": "Hides worlds that have been reset on the Wall Screen or during preview from the world list to avoid lag.",
+  "speedrunapi.config.seedqueue.option.delayFileCreation": "Delay File Creation",
+    "speedrunapi.config.seedqueue.option.delayFileCreation.description": "Delays the creation of world files until world enter.\n Provides significant performance increase for slow storage devices.",
   "speedrunapi.config.seedqueue.option.useWatchdog": "Watchdog",
   "speedrunapi.config.seedqueue.option.useWatchdog.description": "Launches an extra thread that prints out the main threads stacktrace every 10 seconds to diagnose freezing issues.",
   "speedrunapi.config.seedqueue.option.showDebugMenu": "Show Debug Menu",

--- a/src/main/resources/seedqueue.mixins.json
+++ b/src/main/resources/seedqueue.mixins.json
@@ -57,5 +57,11 @@
     "server.synchronization.ScheduledTickMixin",
     "server.synchronization.WeightedBlockStateProviderMixin"
   ],
-  "plugin": "me.contaria.seedqueue.SeedQueueMixinConfigPlugin"
+  "plugin": "me.contaria.seedqueue.SeedQueueMixinConfigPlugin",
+  "mixins": [
+    "server.optimization.FileResourcePackProviderMixin",
+    "server.optimization.LevelStorageSessionMixin",
+    "server.optimization.ServerChunkManagerMixin",
+    "server.optimization.WorldSaveHandlerMixin"
+  ]
 }


### PR DESCRIPTION
When enabled, all files apart from poi region files are not created until the player joins the world. If there are no pois generated before the seed is reset, then the world folder will never be created.
On my machine, enabling the option results in a slight RPS increase